### PR TITLE
feat: allow base layers between data layers

### DIFF
--- a/src/editor/BaseLayerEditor.tsx
+++ b/src/editor/BaseLayerEditor.tsx
@@ -24,5 +24,5 @@ export const BaseLayerEditor: FC<StandardEditorProps<ExtendMapLayerOptions, any,
     return <div>The base layer is configured by the server admin.</div>;
   }
 
-  return <LayerEditor options={value} data={context.data} onChange={onChange} filter={baseMapFilter} />;
+  return <LayerEditor options={value} data={context.data} onChange={onChange} filter={baseMapFilter} showNameField={false} />;
 };

--- a/src/editor/DataLayersEditor.tsx
+++ b/src/editor/DataLayersEditor.tsx
@@ -97,6 +97,7 @@ export const DataLayersEditor: React.FC<StandardEditorProps<ExtendMapLayerOption
                                 onChange(newData);
                               }}
                               filter={dataLayerFilter}
+                              showNameField={true}
                             />
                             <div className="data-layer-remove">
                               <ToolbarButton

--- a/src/editor/DataLayersEditor.tsx
+++ b/src/editor/DataLayersEditor.tsx
@@ -19,9 +19,6 @@ const reorder = (list: ExtendMapLayerOptions[], startIndex: number, endIndex: nu
 };
 
 function dataLayerFilter(layer: ExtendMapLayerRegistryItem): boolean {
-  if (layer.isBaseMap) {
-    return false;
-  }
   if (layer.state === PluginState.alpha) {
     return hasAlphaPanels;
   }

--- a/src/editor/DataLayersEditor.tsx
+++ b/src/editor/DataLayersEditor.tsx
@@ -84,7 +84,7 @@ export const DataLayersEditor: React.FC<StandardEditorProps<ExtendMapLayerOption
                         {/* Controlling a whole draggable by just a part of it: https://github.com/hello-pangea/dnd/blob/main/docs/api/draggable.md#draghandleprops-example-custom-drag-handlem */}
                         <div {...provided.dragHandleProps}> 
                           <IconButton className={styles.grabButton} name="draggabledots" size="lg" iconType="default"
-                              tooltip={"Drag data layer"} variant="secondary"></IconButton>
+                              tooltip={"Drag layer"} variant="secondary"></IconButton>
                         </div>
                           {/* <CollapsableSection label={v.name ? v.name + ' layer' : 'unnamed layer'} isOpen={false}> */}
                           <ControlledCollapse label={v.name ? v.name + ' layer' : 'unnamed layer'} isOpen={false}>

--- a/src/editor/LayerEditor.tsx
+++ b/src/editor/LayerEditor.tsx
@@ -22,9 +22,10 @@ export interface LayerEditorProps<TConfig = any> {
   data: DataFrame[]; // All results
   onChange: (options: ExtendMapLayerOptions<TConfig>) => void;
   filter: (item: ExtendMapLayerRegistryItem) => boolean;
+  showNameField?: boolean; // Show the name field in the options
 }
 
-export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, filter }) => {
+export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, filter, showNameField }) => {
   // all basemaps
   const layerTypes = useMemo(() => {
     return geomapLayerRegistry.selectOptions(
@@ -43,6 +44,16 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
     }
 
     const builder = new PanelOptionsEditorBuilder<ExtendMapLayerOptions>();
+
+    if (showNameField) {
+      builder.addTextInput({
+        path: 'name',
+        name: 'Name',
+        description: 'Layer name',
+        settings: {},
+      });
+    }
+
     if (layer.id === 'nextzen') {
       builder.addTextInput({
         path: 'apiKey',
@@ -54,12 +65,6 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
 
     if (layer.showLocation) {
       builder
-        .addTextInput({
-          path: 'name',
-          name: 'Name',
-          description: 'Layer name',
-          settings: {},
-        })
         .addCustomEditor({
           id: 'query',
           path: 'query',
@@ -206,7 +211,7 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
       // TODO -- add opacity check
     }
     return builder;
-  }, [options?.type]);
+  }, [options?.type, showNameField]);
 
   // The react componnets
   const layerOptions = useMemo(() => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,10 +42,10 @@ export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
     });
 
     builder.addCustomEditor({
-      category: ['Data layer'],
+      category: ['Map layers'],
       id: 'layers',
       path: 'layers',
-      name: 'Data layer',
+      name: 'Map layers',
       editor: DataLayersEditor,
     });
 


### PR DESCRIPTION
This PR allows base layers to be inserted between the data layers.

It does it by doing the following:
- Change the filter for the datalayer editor to include the baselayers.
- Update the LayerEditor to have an option to show the name field. This allows the field to be shown for all types of layers, but only in the data layer section.
- Update the name Data Layer to Map Layers in the GUI since it now includes not only data layers. This is consistent with the Grafana geomap panel.