### PR TITLE
fix: add toggle for data layers to configure if the layer is used in data links

### DIFF
--- a/src/GeomapPanel.tsx
+++ b/src/GeomapPanel.tsx
@@ -149,6 +149,31 @@ export class GeomapPanel extends Component<Props, State> {
 
         let dataFrame: DataFrame = event.payload.data!;
         let rowIndex: number = event.payload.rowIndex!;
+
+        // Return if either dataframe or rowIndex are undefined
+        if (dataFrame === undefined || rowIndex === undefined) {
+          return;
+        }
+
+        // Get options for data layer with refIf of dataframes and check if the data layer is configured for datalinks
+        const dataLayer = this.props.options.layers.find((el) => {
+          try {
+            return el.query!.options === dataFrame.refId;
+          } catch (error) {
+            return false;
+          }
+        })
+
+        if (!dataLayer) {
+          return;
+        }
+
+        // By default 'enabledForDataLinks' is considered to be true, even though it might not be defined.
+        // I.e. the value must be explicitely set to false to be excluded
+        if (dataLayer.enabledForDataLinks !== undefined && dataLayer.enabledForDataLinks === false) {
+          return;
+        }
+
         // let proxyObject = getFieldDisplayValuesProxy({
         //   frame: this.state.ttip!.data!,
         //   rowIndex: this.state.ttip!.rowIndex!

--- a/src/editor/LayerEditor.tsx
+++ b/src/editor/LayerEditor.tsx
@@ -228,6 +228,13 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
         settings: {},
         defaultValue: true
       });
+      builder.addBooleanSwitch({
+        path: 'enabledForDataLinks',
+        name: 'Toggle to include the data layer for data links',
+        description: 'If toggled the layer is used to interpolate the data links URL.',
+        settings: {},
+        defaultValue: true
+      });
     }
 
     if (layer.registerOptionsUI) {
@@ -255,7 +262,8 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
       options: {
         ...options, 
         opacity: options?.opacity === undefined && layer.showOpacity ? 1.0 : options?.opacity,
-        visible: options?.visible === undefined ? true : options?.visible
+        visible: options?.visible === undefined ? true : options?.visible,
+        enabledForDataLinks: options?.enabledForDataLinks === undefined ? true : options?.enabledForDataLinks,
       }
     };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,8 @@ export interface ExtendMapLayerOptions<TConfig = any> {
   displayProperties?: string[];
   titleField?: string;
   timeField?: string;
-  visible?: boolean
+  visible?: boolean;
+  enabledForDataLinks?: boolean;
 }
 
 export interface ExtendMapLayerRegistryItem<TConfig = ExtendMapLayerOptions> extends RegistryItemWithOptions {


### PR DESCRIPTION
If multiple layers with different fields are on the map panel this led to undefined in the dashboard filter if on a feature of an data layer is clicked that does not have the required field name.

Fixes #85