### PR TITLE
fix(mapview): add option to prevent map view reset on dashboard refresh

### DIFF
--- a/src/GeomapPanel.tsx
+++ b/src/GeomapPanel.tsx
@@ -353,13 +353,16 @@ export class GeomapPanel extends Component<Props, State> {
   /**
    * Called when PanelData changes (query results etc)
    */
-  dataChanged(data: PanelData) {
+  dataChanged(data: PanelData, initial=false) { // if called from an initialization function such as initLayers the initial 
+                                                // parameter is set to true to call initMapView and set initial map view
     for (const state of this.layers) {
       if (state.handler.update) {
         state.handler.update(data);
       }
     }
-    if (this.props.options.view.id && this.map) {
+    if (this.props.options.view.id && this.map
+      && (!this.props.options.view.ignoreDashboardRefresh || initial)
+    ) {
       const view = this.initMapView(this.props.options.view);
 
       if (this.map && view) {
@@ -591,7 +594,7 @@ export class GeomapPanel extends Component<Props, State> {
     this.setState({ bottomLeft: legends });
 
     // Update data after init layers
-    this.dataChanged(this.props.data);
+    this.dataChanged(this.props.data, true);
   }
 
   initMapView(config: MapViewConfig): View {

--- a/src/editor/MapViewEditor.tsx
+++ b/src/editor/MapViewEditor.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo, useCallback } from 'react';
 import { StandardEditorProps, SelectableValue } from '@grafana/data';
-import { Button, Combobox, InlineField, InlineFieldRow, ComboboxOption, Stack } from '@grafana/ui';
+import { Button, Combobox, InlineField, InlineFieldRow, ComboboxOption, Stack, Field, Switch } from '@grafana/ui';
 import { GeomapPanelOptions, MapViewConfig } from '../types';
 import { centerPointRegistry, MapCenterID } from '../view';
 import { NumberInput } from '../dimensions/editors/NumberInput';
@@ -118,6 +118,16 @@ export const MapViewEditor: FC<StandardEditorProps<MapViewConfig, any, GeomapPan
       {value?.id === MapCenterID.Fit && (
         <FitMapViewEditor value={value} onChange={onChange} context={context} />
       )}
+      <Field label="Ignore dashboard refresh" description="Toggle to ignore map view updates on dashboard refresh events" aria-label="map view editor ignore dashboard refresh switch">
+        <Switch value={value?.ignoreDashboardRefresh ?? false} onChange={(e) => {
+          onChange(
+            {...value,
+              ignoreDashboardRefresh: e.currentTarget.checked
+            }
+          )
+        }
+        }/>
+      </Field>
     </>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface MapViewConfig {
   padding?: number;
   shared?: boolean;
   zoom?: number;
+  ignoreDashboardRefresh?: boolean;
 }
 
 export const defaultView: MapViewConfig = {


### PR DESCRIPTION
When setting the auto refresh on dashbaords the panel view is reset on every refresh.On near real time applications which needs to refresh the dashoard frequently, that behaviour makes the map unusable for zooming or panning as it is reset on every refresh. To prevent this behaviour a switch is introduced that allows bypassing the initMapView call on  refresh events. To initialize the map view on initial render the dataChanged function was extend with an additional optional parameter indicating initial rendering or not.