### PR TITLE
fix(markerslegend.tsx): use standard options min/max for legend scale…

### DIFF
--- a/src/layers/data/MarkersLegend.tsx
+++ b/src/layers/data/MarkersLegend.tsx
@@ -50,8 +50,8 @@ export function MarkersLegend(props: MarkersLegendProps) {
           className={style.gradientContainer}
           style={{ backgroundImage: `linear-gradient(to right, ${colors.map((c) => c).join(', ')}` }}
         >
-          <div style={{ color: theme.colors.getContrastText(colors[0]) }}>{fmt(colorRange.min)}</div>
-          <div style={{ color: theme.colors.getContrastText(colors[colors.length - 1]) }}>{fmt(colorRange.max)}</div>
+          <div style={{ color: theme.colors.getContrastText(colors[0]) }}>{fmt(color.field?.config?.min ?? colorRange.min)}</div>
+          <div style={{ color: theme.colors.getContrastText(colors[colors.length - 1]) }}>{fmt(color.field?.config?.max ?? colorRange.max)}</div>
         </div>
       </>
     );


### PR DESCRIPTION
by default the linear gradient is computed by the fields min/max value ignoring the standard options min/max. This is fixed by using the coalesce operator which uses the min/max values of the field config object.

fixes #280